### PR TITLE
Use Laby's logging instead of SLF4J

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,10 +9,6 @@ dependencies {
 
     // JSON parsing for server registry
     implementation("com.google.code.gson:gson:2.10.1")
-
-    // Logging: SLF4J API and Logback as runtime implementation
-    implementation("org.slf4j:slf4j-api:2.0.7")
-    runtimeOnly("ch.qos.logback:logback-classic:1.4.11")
 }
 
 labyModAnnotationProcessor {

--- a/core/src/main/java/top/einsluca/autogg/AutoGGAddon.java
+++ b/core/src/main/java/top/einsluca/autogg/AutoGGAddon.java
@@ -12,7 +12,7 @@ import java.util.TimerTask;
 @AddonMain
 public class AutoGGAddon extends LabyAddon<AutoGGConfiguration> {
 
-    private final ServerRegistry serverRegistry = new ServerRegistry();
+    private final ServerRegistry serverRegistry = new ServerRegistry(this);
 
     private boolean alreadySent = false;
 

--- a/core/src/main/java/top/einsluca/autogg/server/ServerRegistry.java
+++ b/core/src/main/java/top/einsluca/autogg/server/ServerRegistry.java
@@ -15,12 +15,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import top.einsluca.autogg.AutoGGAddon;
 
 public class ServerRegistry {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ServerRegistry.class);
 
     private static final String DEFAULT_REMOTE_URL = "https://raw.githubusercontent.com/EinsLucaaa/AutoGG/refs/heads/master/core/src/main/resources/assets/auto-gg/servers.json";
 
@@ -28,19 +25,19 @@ public class ServerRegistry {
 
     private final List<ServerConfiguration> servers = new ArrayList<>();
 
-    public ServerRegistry() {
+    public ServerRegistry(AutoGGAddon addon) {
         String remoteUrl = DEFAULT_REMOTE_URL;
 
         Optional<List<ServerEntry>> remote = Optional.empty();
         try {
             remote = loadFromUrl(remoteUrl);
         } catch (Exception e) {
-            LOGGER.warn("[ServerRegistry] Failed to load remote servers.json from {}: {}", remoteUrl, e.getMessage(), e);
+            addon.logger().warn("[ServerRegistry] Failed to load remote servers.json from {}: {}", remoteUrl, e.getMessage(), e);
         }
 
         if (remote.isPresent()) {
             fillFromEntries(remote.get());
-            LOGGER.info("[ServerRegistry] Loaded server configurations from remote URL: {}", remoteUrl);
+            addon.logger().info("[ServerRegistry] Loaded server configurations from remote URL: {}", remoteUrl);
             return;
         }
 
@@ -48,16 +45,16 @@ public class ServerRegistry {
             Optional<List<ServerEntry>> bundled = loadFromResource();
             if (bundled.isPresent()) {
                 fillFromEntries(bundled.get());
-                LOGGER.info("[ServerRegistry] Loaded server configurations from bundled resource");
+                addon.logger().info("[ServerRegistry] Loaded server configurations from bundled resource");
                 return;
             } else {
-                LOGGER.warn("[ServerRegistry] Bundled servers.json not found or empty");
+                addon.logger().warn("[ServerRegistry] Bundled servers.json not found or empty");
             }
         } catch (Exception e) {
-            LOGGER.warn("[ServerRegistry] Failed to load bundled servers.json: {}", e.getMessage(), e);
+            addon.logger().warn("[ServerRegistry] Failed to load bundled servers.json: {}", e.getMessage(), e);
         }
 
-        LOGGER.info("[ServerRegistry] No server configurations available; registry is empty");
+        addon.logger().info("[ServerRegistry] No server configurations available; registry is empty");
     }
 
     private void fillFromEntries(List<ServerEntry> entries) {


### PR DESCRIPTION
When using other launchers (Prism, vanilla), SLF4J seems to fail with the reason:

"Caused by: java.lang.ClassNotFoundException: Cannot find class 'org.slf4j.LoggerFactory' in any addon"

The solution for this problem is to simply use laby's logging system, as it provides the same logging capabilities as SLF4J without external libraries.