### PR TITLE
fix: remove murderers trigger

### DIFF
--- a/core/src/main/resources/assets/auto-gg/servers.json
+++ b/core/src/main/resources/assets/auto-gg/servers.json
@@ -42,7 +42,7 @@
     },
     {
       "hosts": ["hypixel.net", "mc.hypixel.net"],
-      "identifiers": ["Reward Summary", "1st Killer", "Damage Dealt", "Murderers"],
+      "identifiers": ["Reward Summary", "1st Killer", "Damage Dealt"],
       "separators": [":" ]
     },
     {


### PR DESCRIPTION
Fixes #10 
Tested this change myself and can confirm the addon still works in both modes of murder mystery.